### PR TITLE
Use cached user profile only when check for last used

### DIFF
--- a/unstoppable-ios-app/domains-manager-ios/Services/MessagingService/MessagingService.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Services/MessagingService/MessagingService.swift
@@ -116,11 +116,13 @@ extension MessagingService: MessagingServiceProtocol {
         if let lastUsedWallet = UserDefaults.currentMessagingOwnerWallet,
            let wallet = wallets.first(where: { $0.address == lastUsedWallet }),
            let rrDomain = wallet.reverseResolutionDomain,
-           let profile = try? await getUserProfile(for: rrDomain) {
+           let domain = try? await appContext.dataAggregatorService.getDomainWith(name: rrDomain.name),
+           let profile = try? storageService.getUserProfileFor(domain: domain,
+                                                               serviceIdentifier: apiService.serviceIdentifier) {
             /// User already used chat with some profile, select last used.
             //                try await selectProfileWalletPair(.init(wallet: wallet,
             //                                                        profile: profile))
-            return profile
+            return profile.displayInfo
         }
         return nil
     }


### PR DESCRIPTION
Checking for remote profile can require signature sign that will move to external wallet in some cases. 