### PR TITLE
Various fixes in messages module

### DIFF
--- a/unstoppable-ios-app/domains-manager-ios.xcodeproj/project.pbxproj
+++ b/unstoppable-ios-app/domains-manager-ios.xcodeproj/project.pbxproj
@@ -1282,6 +1282,7 @@
 		C6BEEF3029C30C89000489B9 /* FirebaseNetworkConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BEEF2F29C30C89000489B9 /* FirebaseNetworkConfig.swift */; };
 		C6BF0C5B2B8EDEB4009CB50F /* CheckPendingEventsOnAppearViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BF0C5A2B8EDEB4009CB50F /* CheckPendingEventsOnAppearViewModifier.swift */; };
 		C6BF0C5C2B8EDEB4009CB50F /* CheckPendingEventsOnAppearViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BF0C5A2B8EDEB4009CB50F /* CheckPendingEventsOnAppearViewModifier.swift */; };
+		C6BF6BDA2B8EE724006CC2BD /* PassViewAnalyticsDetailsViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BF6BD92B8EE724006CC2BD /* PassViewAnalyticsDetailsViewModifier.swift */; };
 		C6C1E9342B74C33B00030447 /* AnalyticAppearanceTrackerModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C1E9332B74C33B00030447 /* AnalyticAppearanceTrackerModifier.swift */; };
 		C6C1E9352B74C33B00030447 /* AnalyticAppearanceTrackerModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C1E9332B74C33B00030447 /* AnalyticAppearanceTrackerModifier.swift */; };
 		C6C1EC5A2A3AD2F3005EB37D /* UIMenuDomainAvatarLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C1EC592A3AD2F3005EB37D /* UIMenuDomainAvatarLoader.swift */; };
@@ -3339,6 +3340,7 @@
 		C6BA74732AD5013500628DC6 /* PullUpViewService+DomainProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PullUpViewService+DomainProfile.swift"; sourceTree = "<group>"; };
 		C6BEEF2F29C30C89000489B9 /* FirebaseNetworkConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseNetworkConfig.swift; sourceTree = "<group>"; };
 		C6BF0C5A2B8EDEB4009CB50F /* CheckPendingEventsOnAppearViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckPendingEventsOnAppearViewModifier.swift; sourceTree = "<group>"; };
+		C6BF6BD92B8EE724006CC2BD /* PassViewAnalyticsDetailsViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassViewAnalyticsDetailsViewModifier.swift; sourceTree = "<group>"; };
 		C6C1E9332B74C33B00030447 /* AnalyticAppearanceTrackerModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticAppearanceTrackerModifier.swift; sourceTree = "<group>"; };
 		C6C1EC592A3AD2F3005EB37D /* UIMenuDomainAvatarLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIMenuDomainAvatarLoader.swift; sourceTree = "<group>"; };
 		C6C1EC5E2A3AD483005EB37D /* UIAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAction.swift; sourceTree = "<group>"; };
@@ -6529,6 +6531,7 @@
 				C685803A2B357EF400907568 /* NavBarVisibleModifier.swift */,
 				C6C837A02B5FF307000A6AF5 /* TabBarVisibleModifier.swift */,
 				C663A4D82B7F2FAC0099BCE8 /* PresentationStyleCheckerModifier.swift */,
+				C6BF6BD92B8EE724006CC2BD /* PassViewAnalyticsDetailsViewModifier.swift */,
 				C631DFA02B7B1ED500040221 /* InfiniteRotationModifier.swift */,
 				C6493A012B63A8B700457363 /* TrackingPressingStateModifier.swift */,
 				C6D645792B1D7C2F00D724AC /* PullUpError.swift */,
@@ -9122,6 +9125,7 @@
 				C6B65F502B54DA84006D1812 /* HomeWalletViewModel.swift in Sources */,
 				C685A97B2840BF6200E54044 /* InfoScreen.swift in Sources */,
 				C630BC7B2B183E5700E29318 /* PurchaseDomainsHappyEndViewPresenter.swift in Sources */,
+				C6BF6BDA2B8EE724006CC2BD /* PassViewAnalyticsDetailsViewModifier.swift in Sources */,
 				C630E4B32B7F5835008F3269 /* ExpandableTextEditor.swift in Sources */,
 				C63095EF2B0DA66400205054 /* FirebaseAuthenticationService.swift in Sources */,
 				C666E0C829CC0B5D0003DECB /* FirebaseDomainsStorage.swift in Sources */,

--- a/unstoppable-ios-app/domains-manager-ios.xcodeproj/project.pbxproj
+++ b/unstoppable-ios-app/domains-manager-ios.xcodeproj/project.pbxproj
@@ -1280,6 +1280,8 @@
 		C6BA74722AD4FEE600628DC6 /* PullUpViewService+ExternalWallets.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BA74712AD4FEE600628DC6 /* PullUpViewService+ExternalWallets.swift */; };
 		C6BA74742AD5013500628DC6 /* PullUpViewService+DomainProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BA74732AD5013500628DC6 /* PullUpViewService+DomainProfile.swift */; };
 		C6BEEF3029C30C89000489B9 /* FirebaseNetworkConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BEEF2F29C30C89000489B9 /* FirebaseNetworkConfig.swift */; };
+		C6BF0C5B2B8EDEB4009CB50F /* CheckPendingEventsOnAppearViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BF0C5A2B8EDEB4009CB50F /* CheckPendingEventsOnAppearViewModifier.swift */; };
+		C6BF0C5C2B8EDEB4009CB50F /* CheckPendingEventsOnAppearViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BF0C5A2B8EDEB4009CB50F /* CheckPendingEventsOnAppearViewModifier.swift */; };
 		C6C1E9342B74C33B00030447 /* AnalyticAppearanceTrackerModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C1E9332B74C33B00030447 /* AnalyticAppearanceTrackerModifier.swift */; };
 		C6C1E9352B74C33B00030447 /* AnalyticAppearanceTrackerModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C1E9332B74C33B00030447 /* AnalyticAppearanceTrackerModifier.swift */; };
 		C6C1EC5A2A3AD2F3005EB37D /* UIMenuDomainAvatarLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C1EC592A3AD2F3005EB37D /* UIMenuDomainAvatarLoader.swift */; };
@@ -3336,6 +3338,7 @@
 		C6BA74712AD4FEE600628DC6 /* PullUpViewService+ExternalWallets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PullUpViewService+ExternalWallets.swift"; sourceTree = "<group>"; };
 		C6BA74732AD5013500628DC6 /* PullUpViewService+DomainProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PullUpViewService+DomainProfile.swift"; sourceTree = "<group>"; };
 		C6BEEF2F29C30C89000489B9 /* FirebaseNetworkConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseNetworkConfig.swift; sourceTree = "<group>"; };
+		C6BF0C5A2B8EDEB4009CB50F /* CheckPendingEventsOnAppearViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckPendingEventsOnAppearViewModifier.swift; sourceTree = "<group>"; };
 		C6C1E9332B74C33B00030447 /* AnalyticAppearanceTrackerModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticAppearanceTrackerModifier.swift; sourceTree = "<group>"; };
 		C6C1EC592A3AD2F3005EB37D /* UIMenuDomainAvatarLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIMenuDomainAvatarLoader.swift; sourceTree = "<group>"; };
 		C6C1EC5E2A3AD483005EB37D /* UIAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAction.swift; sourceTree = "<group>"; };
@@ -6517,6 +6520,7 @@
 				C69F991A2A9F1264004B1958 /* AdaptiveSheet.swift */,
 				C6C1E9332B74C33B00030447 /* AnalyticAppearanceTrackerModifier.swift */,
 				C69F99192A9F1264004B1958 /* AvatarStyleClipped.swift */,
+				C6BF0C5A2B8EDEB4009CB50F /* CheckPendingEventsOnAppearViewModifier.swift */,
 				C69F99162A9F1264004B1958 /* ClearListBackground.swift */,
 				C6DA0B742B7C5F68009920B5 /* SectionSpacingModifier.swift */,
 				C6DF46262AA18F8900D124E7 /* DisplayError.swift */,
@@ -8372,6 +8376,7 @@
 				C6A89C4F2B315B8D008AB043 /* HotFeatureSuggestionsService.swift in Sources */,
 				C6D3B9C42A6EBF370091B279 /* XMTPMessagingAPIService.swift in Sources */,
 				C6B65F772B550FC2006D1812 /* WalletNFTsService.swift in Sources */,
+				C6BF0C5B2B8EDEB4009CB50F /* CheckPendingEventsOnAppearViewModifier.swift in Sources */,
 				C685A96F2840A59B00E54044 /* TextBlackButton.swift in Sources */,
 				C692C31F282E485C00C31393 /* SecuritySettingsViewController.swift in Sources */,
 				C6D6463A2B1DC50400D724AC /* AppReviewActionEvent.swift in Sources */,
@@ -9859,6 +9864,7 @@
 				C61807F62B19A7BC0032E543 /* CryptoRecord.swift in Sources */,
 				C6C8F9302B2183C700A9834D /* DomainsCollectionMintingInProgressCell.swift in Sources */,
 				C6C8F8782B21827700A9834D /* LoginWithEmailInAppViewPresenter.swift in Sources */,
+				C6BF0C5C2B8EDEB4009CB50F /* CheckPendingEventsOnAppearViewModifier.swift in Sources */,
 				C607A5CA2B327A600088ECF3 /* PreviewHappyEndViewController.swift in Sources */,
 				C6C8F8D02B21833D00A9834D /* UDBTSearchView.swift in Sources */,
 				C6D6460C2B1DC07200D724AC /* FirebaseDomainDisplayInfo.swift in Sources */,

--- a/unstoppable-ios-app/domains-manager-ios/Entities/Debugger.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Entities/Debugger.swift
@@ -31,7 +31,7 @@ public struct Debugger {
         case WalletConnect = "WC"
         case WalletConnectV2 = "WC_V2"
         case UI = "=UI="
-        case Analytics = "Analtyics"
+        case Analytics = "Analytics"
         case LocalNotification = "LN"
         case Images = "IMG"
         case DataAggregation = "AGGR"

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Home/HomeTabRouter.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Home/HomeTabRouter.swift
@@ -108,9 +108,12 @@ extension HomeTabRouter {
     func showDomainProfile(_ domain: DomainDisplayInfo,
                            wallet: WalletEntity,
                            preRequestedAction: PreRequestedProfileAction?,
+                           shouldResetNavigation: Bool = true,
                            dismissCallback: EmptyCallback?) async {
-        await popToRootAndWait()
-        tabViewSelection = .wallets
+        if shouldResetNavigation {
+            await popToRootAndWait()
+            tabViewSelection = .wallets
+        }
         await askToFinishSetupPurchasedProfileIfNeeded(domains: wallet.domains)
         guard let topVC = appContext.coreAppCoordinator.topVC else { return }
 

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Home/HomeView.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Home/HomeView.swift
@@ -32,8 +32,7 @@ struct HomeView: View, ViewAnalyticsLogger {
                         .ignoresSafeArea()
                 }
                 .trackAppearanceAnalytics(analyticsLogger: self)
-                .environment(\.analyticsViewName, analyticsName)
-                .environment(\.analyticsAdditionalProperties, additionalAppearAnalyticParameters)
+                .passViewAnalyticsDetails(logger: self)
                 .checkPendingEventsOnAppear()
 
         }, navigationStateProvider: { state in

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Home/HomeView.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Home/HomeView.swift
@@ -34,6 +34,7 @@ struct HomeView: View, ViewAnalyticsLogger {
                 .trackAppearanceAnalytics(analyticsLogger: self)
                 .environment(\.analyticsViewName, analyticsName)
                 .environment(\.analyticsAdditionalProperties, additionalAppearAnalyticParameters)
+                .checkPendingEventsOnAppear()
 
         }, navigationStateProvider: { state in
             self.navigationState = state

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChannelView/ChannelView.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChannelView/ChannelView.swift
@@ -27,8 +27,6 @@ struct ChannelView: View, ViewAnalyticsLogger {
                 ProgressView()
             }
         }
-        .environment(\.analyticsViewName, analyticsName)
-        .environment(\.analyticsAdditionalProperties, additionalAppearAnalyticParameters)
         .displayError($viewModel.error)
         .background(Color.backgroundMuted2)
         .toolbar {
@@ -45,6 +43,7 @@ struct ChannelView: View, ViewAnalyticsLogger {
                     .background(.regularMaterial)
             }
         }
+        .passViewAnalyticsDetails(logger: self)
         .onAppear(perform: onAppear)
     }
     

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/Chat.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/Chat.swift
@@ -56,6 +56,7 @@ extension Chat {
         case copyText(String)
         case sendReaction(content: String, toMessage: MessagingChatMessageDisplayInfo)
         case saveImage(UIImage)
+        case showImage(UIImage)
         case blockUserInGroup(MessagingChatUserDisplayInfo)
         case reply(MessagingChatMessageDisplayInfo)
     }

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/ChatMentionSuggestionsView.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/ChatMentionSuggestionsView.swift
@@ -7,7 +7,10 @@
 
 import SwiftUI
 
-struct ChatMentionSuggestionsView: View {
+struct ChatMentionSuggestionsView: View, ViewAnalyticsLogger {
+    
+    @Environment(\.analyticsViewName) var analyticsName
+    @Environment(\.analyticsAdditionalProperties) var additionalAppearAnalyticParameters
     
     let suggestingUsers: [MessagingChatUserDisplayInfo]
     let selectionCallback: (MessagingChatUserDisplayInfo)->()
@@ -36,6 +39,7 @@ private extension ChatMentionSuggestionsView {
     @ViewBuilder
     func selectableRowViewFor(user: MessagingChatUserDisplayInfo) -> some View {
         Button {
+            logButtonPressedAnalyticEvents(button: .messagingMentionSuggestion)
             UDVibration.buttonTap.vibrate()
             selectionCallback(user)
         } label: {

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/ChatNavTitleView.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/ChatNavTitleView.swift
@@ -24,9 +24,10 @@ struct ChatNavTitleView: View {
                 .foregroundStyle(Color.foregroundDefault)
                 .font(.currentFont(size: 16, weight: .semibold))
         }
-        .task {
-            await loadIcon()
-        }
+        .onChange(of: titleType, perform: { newValue in
+            loadIconNonBlocking()
+        })
+        .onAppear(perform: loadIconNonBlocking)
     }
     
     private var title: String {
@@ -41,6 +42,12 @@ struct ChatNavTitleView: View {
             return messagingGroupChatDetails.displayName
         case .community(let messagingCommunitiesChatDetails):
             return messagingCommunitiesChatDetails.displayName
+        }
+    }
+    
+    private func loadIconNonBlocking() {
+        Task {
+            await loadIcon()
         }
     }
     
@@ -64,7 +71,7 @@ struct ChatNavTitleView: View {
         }
     }
     
-    enum TitleType {
+    enum TitleType: Hashable {
         case domainName(DomainName)
         case walletAddress(HexAddress)
         case channel(MessagingNewsChannel)

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/ChatReplyInfoView.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/ChatReplyInfoView.swift
@@ -7,10 +7,12 @@
 
 import SwiftUI
 
-struct ChatReplyInfoView: View {
+struct ChatReplyInfoView: View, ViewAnalyticsLogger {
     
     @EnvironmentObject var viewModel: ChatViewModel
-
+    @Environment(\.analyticsViewName) var analyticsName
+    @Environment(\.analyticsAdditionalProperties) var additionalAppearAnalyticParameters
+    
     let messageToReply: MessagingChatMessageDisplayInfo
     
     var body: some View {
@@ -48,6 +50,7 @@ private extension ChatReplyInfoView {
     func clickableMessageDescriptionView() -> some View {
         Button {
             UDVibration.buttonTap.vibrate()
+            logButtonPressedAnalyticEvents(button: .jumpToMessageToReply)
             withAnimation {
                 viewModel.didTapJumpToReplyButton()
             }
@@ -85,6 +88,7 @@ private extension ChatReplyInfoView {
     @ViewBuilder
     func removeReplyView() -> some View {
         Button {
+            logButtonPressedAnalyticEvents(button: .cancelReply)
             UDVibration.buttonTap.vibrate()
             withAnimation {
                 viewModel.didTapRemoveReplyButton()

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/ChatView.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/ChatView.swift
@@ -14,7 +14,6 @@ struct ChatView: View, ViewAnalyticsLogger {
     @FocusState var focused: Bool
 
     var analyticsName: Analytics.ViewName { .chatDialog }
-    var additionalAppearAnalyticParameters: Analytics.EventParameters { [:] }
     
     var body: some View {
         ZStack {
@@ -55,8 +54,7 @@ struct ChatView: View, ViewAnalyticsLogger {
             }
         }
         .environmentObject(viewModel)
-        .environment(\.analyticsViewName, analyticsName)
-        .environment(\.analyticsAdditionalProperties, additionalAppearAnalyticParameters)
+        .passViewAnalyticsDetails(logger: self)
         .onAppear(perform: onAppear)
     }
 }

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/ChatViewModel.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/ChatViewModel.swift
@@ -978,6 +978,7 @@ private extension ChatViewModel {
             await router.showDomainProfile(domain,
                                            wallet: wallet,
                                            preRequestedAction: action,
+                                           shouldResetNavigation: false,
                                            dismissCallback: nil)
         case .showPublicDomainProfile(let publicDomainDisplayInfo, let wallet, let action):
             router.showPublicDomainProfile(of: publicDomainDisplayInfo,

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/ChatViewModel.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/ChatViewModel.swift
@@ -290,10 +290,7 @@ private extension ChatViewModel {
     
     func parseMentionDomainNameFrom(url: URL) -> String? {
         let string = url.absoluteString
-        if string.first == "@" {
-            return String(string.dropFirst())
-        }
-        return nil
+        return MessageMentionString(string: string)?.mentionWithoutPrefix
     }
     
     func handleOtherLinkPressed(_ url: URL, by sender: MessagingChatSender) {

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/ChatViewModel.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/ChatViewModel.swift
@@ -167,6 +167,9 @@ extension ChatViewModel {
             logButtonPressedAnalyticEvents(button: .saveChatImage)
             let saver = PhotoLibraryImageSaver()
             saver.saveImage(image)
+        case .showImage(let image):
+            logButtonPressedAnalyticEvents(button: .viewMessagePhoto)
+            showMessageImageViewWith(image: image, mode: .view)
         case .blockUserInGroup(let user):
             logButtonPressedAnalyticEvents(button: .blockUserInGroupChat,
                                            parameters: [.chatId : chat.id,
@@ -175,6 +178,7 @@ extension ChatViewModel {
                 try? await setUser(user, in: chat, blocked: true)
             }
         case .sendReaction(let content, let toMessage):
+            logButtonPressedAnalyticEvents(button: .sendReaction, parameters: [.value: content])
             sendReactionMessage(content, toMessage: toMessage)
         case .reply(let message):
             messageToReply = message
@@ -987,11 +991,14 @@ private extension ChatViewModel {
 private extension ChatViewModel {
     func didPickImageToSend(_ image: UIImage) {
         let resizedImage = image.resized(to: Constants.maxImageResolution) ?? image
-        
-        let confirmationVC = MessagingImageView.instantiate(mode: .confirmSending(callback: { [weak self] in
+        showMessageImageViewWith(image: resizedImage, mode: .confirmSending(callback: { [weak self] in
             self?.sendImageMessage(resizedImage)
-        }), image: resizedImage)
-        appContext.coreAppCoordinator.topVC?.present(confirmationVC, animated: true)
+        }))
+    }
+    
+    func showMessageImageViewWith(image: UIImage, mode: MessagingImageView.Mode) {
+        let messagingImageVC = MessagingImageView.instantiate(mode: mode, image: image)
+        appContext.coreAppCoordinator.topVC?.present(messagingImageVC, animated: true)
     }
 }
 

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/ChatViewModel.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/ChatViewModel.swift
@@ -181,6 +181,7 @@ extension ChatViewModel {
             logButtonPressedAnalyticEvents(button: .sendReaction, parameters: [.value: content])
             sendReactionMessage(content, toMessage: toMessage)
         case .reply(let message):
+            logButtonPressedAnalyticEvents(button: .replyToMessage)
             messageToReply = message
             keyboardFocused = true
         }
@@ -270,8 +271,10 @@ private extension ChatViewModel {
     
     func verifyAndHandleExternalLink(_ url: URL, by sender: MessagingChatSender) {
         if let domainName = parseMentionDomainNameFrom(url: url) {
+            logButtonPressedAnalyticEvents(button: .mentionWithinMessage, parameters: [.value: domainName])
             handleMentionPressedTo(domainName: domainName)
         } else {
+            logButtonPressedAnalyticEvents(button: .linkWithinMessage)
             handleOtherLinkPressed(url, by: sender)
         }
     }

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/Messages/MessageRowView.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/Messages/MessageRowView.swift
@@ -312,7 +312,7 @@ private extension MessageRowView {
                 }
                     .animation(.linear, value: offset)
                     .offset(x: offset)
-                    .simultaneousGesture(
+                    .highPriorityGesture(
                         DragGesture()
                             .onChanged { gesture in
                                 let translation = gesture.translation.width

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/Messages/MessageRowView.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/Messages/MessageRowView.swift
@@ -7,10 +7,12 @@
 
 import SwiftUI
 
-struct MessageRowView: View {
+struct MessageRowView: View, ViewAnalyticsLogger {
     
     @EnvironmentObject var viewModel: ChatViewModel
-
+    @Environment(\.analyticsViewName) var analyticsName
+    @Environment(\.analyticsAdditionalProperties) var additionalAppearAnalyticParameters
+    
     let message: MessagingChatMessageDisplayInfo
     let isGroupChatMessage: Bool
     @State private var otherUserAvatar: UIImage?
@@ -236,6 +238,7 @@ private extension MessageRowView {
     func addReactionButtonView() -> some View {
         Button {
             UDVibration.buttonTap.vibrate()
+            logButtonPressedAnalyticEvents(button: .selectReaction)
             showingReactionsPopover = true
         } label: {
             HStack(spacing: 2) {
@@ -286,9 +289,11 @@ private extension MessageRowView {
 
 // MARK: - Private methods
 private extension MessageRowView {
-    struct SwipeToReplyGestureModifier: ViewModifier {
+    struct SwipeToReplyGestureModifier: ViewModifier, ViewAnalyticsLogger {
         
         @EnvironmentObject var viewModel: ChatViewModel
+        @Environment(\.analyticsViewName) var analyticsName
+        @Environment(\.analyticsAdditionalProperties) var additionalAppearAnalyticParameters
 
         let message: MessagingChatMessageDisplayInfo
         @State private var offset: CGFloat = 0
@@ -369,6 +374,7 @@ private extension MessageRowView {
         }
         
         private func didSwipeToReply() {
+            logButtonPressedAnalyticEvents(button: .didSwipeToReply)
             viewModel.handleChatMessageAction(.reply(message))
         }
         

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/Messages/Rows/ImageMessageRowView.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/ChatView/Messages/Rows/ImageMessageRowView.swift
@@ -17,19 +17,7 @@ struct ImageMessageRowView: View {
 
     var body: some View {
         ZStack {
-            if let image {
-                UIImageBridgeView(image: image,
-                                  width: 20,
-                                  height: 20)
-                .frame(width: imageSize().width,
-                       height: imageSize().height)
-            } else {
-                Image.framesIcon
-                    .resizable()
-                    .squareFrame(80)
-                    .padding(60)
-                    .background(Color.backgroundMuted)
-            }
+            messageImageView()
         }
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .contextMenu {
@@ -54,6 +42,34 @@ struct ImageMessageRowView: View {
 
 // MARK: - Private methods
 private extension ImageMessageRowView {
+    @ViewBuilder
+    func messageImageView() -> some View {
+        if let image {
+            clickableMessageImageView(image: image)
+        } else {
+            Image.framesIcon
+                .resizable()
+                .squareFrame(80)
+                .padding(60)
+                .background(Color.backgroundMuted)
+        }
+    }
+    
+    @ViewBuilder
+    func clickableMessageImageView(image: UIImage) -> some View {
+        Button {
+            UDVibration.buttonTap.vibrate()
+            viewModel.handleChatMessageAction(.showImage(image))
+        } label: {
+            UIImageBridgeView(image: image,
+                              width: 20,
+                              height: 20)
+            .frame(width: imageSize().width,
+                   height: imageSize().height)
+        }
+        .buttonStyle(.plain)
+    }
+    
     func imageSize() -> CGSize {
         if let imageSize = image?.size {
             let maxSize: CGFloat = (224/390) * UIScreen.main.bounds.width

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/MessagingImageView.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Chat/MessagingImageView.swift
@@ -7,7 +7,11 @@
 
 import SwiftUI
 
-struct MessagingImageView: View {
+struct MessagingImageView: View, ViewAnalyticsLogger {
+    
+    
+    var analyticsName: Analytics.ViewName { .viewMessagingImage }
+    
     
     @MainActor
     static func instantiate(mode: MessagingImageView.Mode,
@@ -36,10 +40,12 @@ struct MessagingImageView: View {
                             .aspectRatio(contentMode: .fit)
                     }
                 }
+                .trackAppearanceAnalytics(analyticsLogger: self)
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
                         Button(action: {
                             UDVibration.buttonTap.vibrate()
+                            logButtonPressedAnalyticEvents(button: .cancel)
                             dismiss()
                         }) {
                             Text(String.Constants.cancel.localized())
@@ -53,6 +59,7 @@ struct MessagingImageView: View {
                         case .confirmSending(let callback):
                             Button(action: {
                                 UDVibration.buttonTap.vibrate()
+                                logButtonPressedAnalyticEvents(button: .send)
                                 dismiss()
                                 callback()
                             }) {
@@ -66,6 +73,7 @@ struct MessagingImageView: View {
                             }
                         case .view:
                             Button(action: {
+                                logButtonPressedAnalyticEvents(button: .savePhoto)
                                 UDVibration.buttonTap.vibrate()
                                 let saver = PhotoLibraryImageSaver()
                                 saver.saveImage(image)

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/ChatsList/ChatListView.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/ChatsList/ChatListView.swift
@@ -83,6 +83,7 @@ struct ChatListView: View, ViewAnalyticsLogger {
                                                           tabRouter: tabRouter)
                 .environmentObject(navigationState!)
             }
+            .checkPendingEventsOnAppear()
         }, navigationStateProvider: { state in
             self.navigationState = state
         }, path: $tabRouter.chatTabNavPath)

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/ChatsList/ChatListView.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/ChatsList/ChatListView.swift
@@ -40,6 +40,7 @@ struct ChatListView: View, ViewAnalyticsLogger {
                     ProgressView()
                 }
             }
+            .trackAppearanceAnalytics(analyticsLogger: self)
             .displayError($viewModel.error)
             .background(Color.backgroundMuted2)
             .onReceive(keyboardPublisher) { value in
@@ -83,6 +84,7 @@ struct ChatListView: View, ViewAnalyticsLogger {
                                                           tabRouter: tabRouter)
                 .environmentObject(navigationState!)
             }
+            .passViewAnalyticsDetails(logger: self)
             .checkPendingEventsOnAppear()
         }, navigationStateProvider: { state in
             self.navigationState = state

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/ChatsList/ChatListView.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/ChatsList/ChatListView.swift
@@ -165,7 +165,8 @@ private extension ChatListView {
                          icon: bioImage,
                          style: .large(.raisedPrimary),
                          callback: {
-                
+                logButtonPressedAnalyticEvents(button: .createMessagingProfile)
+                viewModel.createProfilePressed()
             })
             .padding()
         }
@@ -194,8 +195,8 @@ private extension ChatListView {
                        buttonIcon: .plusIcon18,
                        buttonStyle: .medium(.raisedPrimary),
                        buttonCallback: {
-            logButtonPressedAnalyticEvents(button: .createMessagingProfile)
-            viewModel.createProfilePressed()
+            logButtonPressedAnalyticEvents(button: .addWallet)
+            viewModel.addWalletButtonPressed()
         })
     }
     

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/ChatsList/ChatListViewModel.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/ChatsList/ChatListViewModel.swift
@@ -167,6 +167,10 @@ extension ChatListViewModel {
         }
     }
     
+    func addWalletButtonPressed() {
+        router.runAddWalletFlow(initialAction: .showAllAddWalletOptionsPullUp)
+    }
+    
     func createCommunitiesProfileButtonPressed() {
         Task {
             guard let selectedProfileWalletPair,

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/ChatsList/ChatListViewModel.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/ChatsList/ChatListViewModel.swift
@@ -257,8 +257,23 @@ extension ChatListViewModel: ChatsListCoordinator {
                         tryAutoOpenChannel(channelId, profile: profile)
                     }
                 }
+                syncSelectedProfileWithMessaging()
             } catch {
                 self.error = error
+            }
+        }
+    }
+    
+    private func syncSelectedProfileWithMessaging() {
+        switch selectedProfile {
+        case .wallet(let wallet):
+            if let selectedMessagingWallet = selectedProfileWalletPair?.wallet,
+               wallet.address != selectedMessagingWallet.address  {
+                appContext.userProfileService.setSelectedProfile(.wallet(selectedMessagingWallet))
+            }
+        case .webAccount:
+            if let selectedMessagingWallet = selectedProfileWalletPair?.wallet {
+                appContext.userProfileService.setSelectedProfile(.wallet(selectedMessagingWallet))
             }
         }
     }

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/ChatsList/ChatListViews/ChatListDataTypeSelectorView.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/ChatsList/ChatListViews/ChatListDataTypeSelectorView.swift
@@ -7,10 +7,12 @@
 
 import SwiftUI
 
-struct ChatListDataTypeSelectorView: View {
+struct ChatListDataTypeSelectorView: View, ViewAnalyticsLogger {
     
     @EnvironmentObject var viewModel: ChatListViewModel
+    @Environment(\.analyticsViewName) var analyticsName
     @Binding var dataType: ChatsList.DataType
+    
 
     private let indicatorSize: CGFloat = 4
     
@@ -81,6 +83,7 @@ private extension ChatListDataTypeSelectorView {
     func viewForSegmentWith(dataType: ChatsList.DataType) -> some View {
         Button {
             UDVibration.buttonTap.vibrate()
+            logButtonPressedAnalyticEvents(button: .messagingDataType, parameters: [.value : dataType.rawValue])
             if self.dataType != dataType {
                 self.dataType = dataType
             }

--- a/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Entities/Messages/MessagingChatMessageDisplayInfo.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/Messaging/Entities/Messages/MessagingChatMessageDisplayInfo.swift
@@ -47,6 +47,13 @@ extension MessagingChatMessageDisplayInfo {
         deliveryState == .failedToSend
     }
     
+    var isReactionMessage: Bool {
+        if case .reaction = type {
+            return true
+        }
+        return false
+    }
+    
     enum DeliveryState: Int {
         case delivered, sending, failedToSend
     }

--- a/unstoppable-ios-app/domains-manager-ios/Modules/PurchaseDomains/Checkout/PurchaseDomainsCheckoutView.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Modules/PurchaseDomains/Checkout/PurchaseDomainsCheckoutView.swift
@@ -84,11 +84,11 @@ struct PurchaseDomainsCheckoutView: View, ViewAnalyticsLogger {
                                       selectedWalletCallback: { wallet in warnUserIfNeededAndSelectWallet(wallet) }))
         .sheet(isPresented: $isEnterZIPCodePresented, content: {
             PurchaseDomainsEnterZIPCodeView()
-                .environment(\.analyticsViewName, analyticsName)
+                .passViewAnalyticsDetails(logger: self)
         })
         .sheet(isPresented: $isEnterDiscountCodePresented, content: {
             PurchaseDomainsEnterDiscountCodeView()
-                .environment(\.analyticsViewName, analyticsName)
+                .passViewAnalyticsDetails(logger: self)
         })
         .pullUpError($error)
         .modifier(ShowingSelectDiscounts(isSelectDiscountsPresented: $isSelectDiscountsPresented))

--- a/unstoppable-ios-app/domains-manager-ios/Services/AnalyticsService/AnalyticsServiceEnvironment.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Services/AnalyticsService/AnalyticsServiceEnvironment.swift
@@ -217,6 +217,7 @@ extension Analytics {
         case shakeToFind
         case purchaseDomainsSearch, purchaseDomainsCheckout, purchaseDomainsProfile
         case hotFeatureDetails
+        case viewMessagingImage
         
         case shareWalletInfo, nftDetails, profileSelection
         case updateToWalletGreetings
@@ -227,7 +228,7 @@ extension Analytics {
 extension Analytics {
     enum Button: String, Codable {
         case buyDomains, mintDomains, manageDomains, importFromTheWebsite
-        case skip, `continue`, learnMore, done, update, close, confirm, clear, share, cancel, gotIt, delete, pay, later, edit, verify, open, refresh, tryAgain, next, lock, logOut
+        case skip, `continue`, learnMore, done, update, close, confirm, clear, share, cancel, gotIt, delete, pay, later, edit, verify, open, refresh, tryAgain, next, lock, logOut, send
         case copyToClipboard, pasteFromClipboard
         case agreeCheckbox
         case termsOfUse, privacyPolicy
@@ -348,6 +349,9 @@ extension Analytics {
         case chatInputActions, takePhoto, choosePhoto
         case viewMessagePhoto
         case selectReaction, sendReaction
+        case didSwipeToReply, jumpToMessageToReply, cancelReply, replyToMessage
+        case mentionWithinMessage, messagingMentionSuggestion
+        case linkWithinMessage
 
         // Public profile
         case follow, unfollow

--- a/unstoppable-ios-app/domains-manager-ios/Services/AnalyticsService/AnalyticsServiceEnvironment.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Services/AnalyticsService/AnalyticsServiceEnvironment.swift
@@ -346,6 +346,8 @@ extension Analytics {
         case saveChatImage
         case blockUserInGroupChat
         case chatInputActions, takePhoto, choosePhoto
+        case viewMessagePhoto
+        case selectReaction, sendReaction
 
         // Public profile
         case follow, unfollow

--- a/unstoppable-ios-app/domains-manager-ios/Services/CoreAppCoordinator/CoreAppCoordinator.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Services/CoreAppCoordinator/CoreAppCoordinator.swift
@@ -105,6 +105,13 @@ extension CoreAppCoordinator: DeepLinkServiceListener {
 
 // MARK: - ExternalEventsUIHandler
 extension CoreAppCoordinator: ExternalEventsUIHandler {
+    var isReadyToHandleExternalEvents: Bool {
+        if case .home = currentRoot {
+            return true
+        }
+        return false
+    }
+    
     func handle(uiFlow: ExternalEventUIFlow) async throws {
         switch currentRoot {
         case .home(let router):

--- a/unstoppable-ios-app/domains-manager-ios/Services/ExternalEventsService/ExternalEventsServiceProtocol.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Services/ExternalEventsService/ExternalEventsServiceProtocol.swift
@@ -44,5 +44,6 @@ typealias ExternalEventUIHandleCompletion = (Bool) -> ()
 
 @MainActor
 protocol ExternalEventsUIHandler {
+    var isReadyToHandleExternalEvents: Bool { get }
     func handle(uiFlow: ExternalEventUIFlow) async throws
 }

--- a/unstoppable-ios-app/domains-manager-ios/Services/Firebase/Purchase/FirebasePurchaseEntities.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Services/Firebase/Purchase/FirebasePurchaseEntities.swift
@@ -247,27 +247,6 @@ extension FirebasePurchaseDomainsService {
         let referralCode: String
         let storeCredits: Int
         let uid: String
-        
-        struct Subscription: Codable {
-            let id: Int
-            let cancelledAt: String?
-            let createdAt: String
-            let expiresAt: String
-            let price: Int
-            let status: String
-            let userId: Int
-            let trial: Bool
-            let type: String
-            let domain: String?
-            let billingType: String
-            let externalProviderId: String?
-            let externalProvider: String?
-        }
-        
-        struct Domain: Codable {
-            let name: String
-            let address: String
-        }
     }
     
     struct UDUserAccountCryptWalletsResponse: Codable {

--- a/unstoppable-ios-app/domains-manager-ios/Services/MessagingService/Push/PushEntitiesTransformer.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Services/MessagingService/Push/PushEntitiesTransformer.swift
@@ -389,7 +389,7 @@ private extension PushEntitiesTransformer {
         }
         
         return try parseMessageFromPushMessage(decryptedContent: decryptedContent,
-                                               messageObj: messageObj,
+                                               messageObj: messageObj ?? pushMessage.messageObj,
                                                messageType: messageType,
                                                messageId: messageId,
                                                userId: userId,
@@ -413,13 +413,15 @@ private extension PushEntitiesTransformer {
             return .imageBase64(imageBase64DisplayInfo)
         case .reaction:
             guard let messageObj,
-                  let contentInfo = PushEnvironment.PushMessageReactionContent.objectFromJSONString(messageObj) else { return nil }
+                  let contentInfo = PushEnvironment.PushMessageReactionContent.objectFromJSONString(messageObj) else { 
+                return nil }
             let messageId = parseReferenceIdToMessage(from: contentInfo.reference)
             return .reaction(.init(content: contentInfo.content, messageId: messageId))
         case .reply:
             guard let messageObj,
                   let contentInfo = PushEnvironment.PushMessageReplyContent.objectFromJSONString(messageObj),
-                  let messageType = PushMessageType(rawValue: contentInfo.content.messageType) else { return nil }
+                  let messageType = PushMessageType(rawValue: contentInfo.content.messageType) else { 
+                return nil }
             guard let contentType = try parseMessageFromPushMessage(decryptedContent: contentInfo.content.messageObj.content,
                                                                     messageObj: nil,
                                                                     messageType: messageType,

--- a/unstoppable-ios-app/domains-manager-ios/Services/MessagingService/Push/PushEnvironment.swift
+++ b/unstoppable-ios-app/domains-manager-ios/Services/MessagingService/Push/PushEnvironment.swift
@@ -44,7 +44,26 @@ enum PushEnvironment {
         
         enum CodingKeys: String, CodingKey {
             case content
-            case reference = "refrence"
+            case reference
+            case alternateReference = "refrence"
+        }
+        
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            
+            self.content = try container.decode(String.self, forKey: .content)
+            if let primaryReference = try? container.decodeIfPresent(String.self, forKey: .reference) {
+                self.reference = primaryReference
+            } else {
+                self.reference = try container.decode(String.self, forKey: .alternateReference)
+            }
+        }
+        
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(content, forKey: .content)
+            try container.encode(reference, forKey: .reference)
         }
     }
     

--- a/unstoppable-ios-app/domains-manager-ios/SwiftUI/ViewModifiers/CheckPendingEventsOnAppearViewModifier.swift
+++ b/unstoppable-ios-app/domains-manager-ios/SwiftUI/ViewModifiers/CheckPendingEventsOnAppearViewModifier.swift
@@ -1,0 +1,24 @@
+//
+//  CheckPendingEventsOnAppearViewModifier.swift
+//  domains-manager-ios
+//
+//  Created by Oleg Kuplin on 28.02.2024.
+//
+
+import SwiftUI
+
+struct CheckPendingEventsOnAppearViewModifier: ViewModifier {
+    
+    func body(content: Content) -> some View {
+        content.onAppear {
+            appContext.externalEventsService.checkPendingEvents()
+        }
+    }
+    
+}
+
+extension View {
+    func checkPendingEventsOnAppear() -> some View {
+        self.modifier(CheckPendingEventsOnAppearViewModifier())
+    }
+}

--- a/unstoppable-ios-app/domains-manager-ios/SwiftUI/ViewModifiers/PassViewAnalyticsDetailsViewModifier.swift
+++ b/unstoppable-ios-app/domains-manager-ios/SwiftUI/ViewModifiers/PassViewAnalyticsDetailsViewModifier.swift
@@ -1,0 +1,28 @@
+//
+//  PassViewAnalyticsDetailsViewModifier.swift
+//  domains-manager-ios
+//
+//  Created by Oleg Kuplin on 28.02.2024.
+//
+
+import SwiftUI
+
+struct PassViewAnalyticsDetailsViewModifier: ViewModifier {
+    
+    let analyticsName: Analytics.ViewName
+    let additionalAppearAnalyticParameters: Analytics.EventParameters
+    
+    func body(content: Content) -> some View {
+        content
+            .environment(\.analyticsViewName, analyticsName)
+            .environment(\.analyticsAdditionalProperties, additionalAppearAnalyticParameters)
+    }
+    
+}
+
+extension View {
+    func passViewAnalyticsDetails(logger: ViewAnalyticsLogger) -> some View {
+        self.modifier(PassViewAnalyticsDetailsViewModifier(analyticsName: logger.analyticsName,
+                                                           additionalAppearAnalyticParameters: logger.additionalAppearAnalyticParameters))
+    }
+}


### PR DESCRIPTION
Handle Push unencrypted messageObj
Handle Push misspelled property name
Fixed issue when reaction could be duplicated on the UI after added
Increased number of loaded messages to 30 per batch
Fixed issue when chat wasn't opened after tap on PN
Sync messaging and user profiles after PN received
Restored view image functionality
Don’t jump to home when select own domain from messaging 
Swipe to reply with image message gestures conflict 
Messages analytics 
